### PR TITLE
Update tessdata.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     rappdirs,
     digest
 LinkingTo: Rcpp
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Suggests:
     magick (>= 1.7),

--- a/R/tessdata.R
+++ b/R/tessdata.R
@@ -1,7 +1,7 @@
 #' Tesseract Training Data
 #'
 #' Helper function to download training data from the official
-#' [tessdata](https://github.com/tesseract-ocr/tesseract/wiki/Data-Files) repository. Only use this function on
+#' [tessdata](https://tesseract-ocr.github.io/tessdoc/Data-Files) repository. Only use this function on
 #' Windows and OS-X. On Linux, training data can be installed directly with
 #' [yum](https://apps.fedoraproject.org/packages/tesseract) or
 #' [apt-get](https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=tesseract-ocr-).
@@ -24,7 +24,7 @@
 #' @param lang three letter code for language, see [tessdata](https://github.com/tesseract-ocr/tessdata) repository.
 #' @param datapath destination directory where to download store the file
 #' @param progress print progress while downloading
-#' @references [tesseract wiki: training data](https://github.com/tesseract-ocr/tesseract/wiki/Data-Files)
+#' @references [tesseract wiki: training data](https://tesseract-ocr.github.io/tessdoc/Data-Files)
 #' @examples \donttest{
 #' if(is.na(match("fra", tesseract_info()$available)))
 #'   tesseract_download("fra")

--- a/man/tessdata.Rd
+++ b/man/tessdata.Rd
@@ -16,7 +16,7 @@ tesseract_download(lang, datapath = NULL, progress = interactive())
 }
 \description{
 Helper function to download training data from the official
-\href{https://github.com/tesseract-ocr/tesseract/wiki/Data-Files}{tessdata} repository. Only use this function on
+\href{https://tesseract-ocr.github.io/tessdoc/Data-Files}{tessdata} repository. Only use this function on
 Windows and OS-X. On Linux, training data can be installed directly with
 \href{https://apps.fedoraproject.org/packages/tesseract}{yum} or
 \href{https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=tesseract-ocr-}{apt-get}.
@@ -44,7 +44,7 @@ cat(text)
 }
 }
 \references{
-\href{https://github.com/tesseract-ocr/tesseract/wiki/Data-Files}{tesseract wiki: training data}
+\href{https://tesseract-ocr.github.io/tessdoc/Data-Files}{tesseract wiki: training data}
 }
 \seealso{
 Other tesseract: 


### PR DESCRIPTION
All pages were moved to tesseract-ocr/tessdoc.

The latest documentation is available at https://tesseract-ocr.github.io/.