### PR TITLE
small PR to normalize relative paths so it works on C++ side

### DIFF
--- a/R/tesseract.R
+++ b/R/tesseract.R
@@ -23,7 +23,7 @@
 tesseract <- local({
   store <- new.env()
   function(language = "eng", datapath = NULL, configs = NULL, options = NULL, cache = TRUE){
-    datapath <- as.character(datapath)
+    datapath <- normalizePath(as.character(datapath), mustWork = TRUE)
     language <- as.character(language)
     configs <- as.character(configs)
     options <- as.list(options)


### PR DESCRIPTION
in the current codebase this works

```
dir <- "/home/pacha/Downloads"

tesseract_download("chi_sim_vert", datapath = dir, model = "best")
tesseract_download("chi_sim", datapath = dir, model = "best")

# compare the results: fast (text1) vs best (text2)
text1 <- ocr(file, engine = tesseract("chi_sim"))
text2 <- ocr(file, engine = tesseract("chi_sim", datapath = dir))
```

this won't

```
dir <- "~/Downloads"

tesseract_download("chi_sim_vert", datapath = dir, model = "best")
tesseract_download("chi_sim", datapath = dir, model = "best")

# compare the results: fast (text1) vs best (text2)
text1 <- ocr(file, engine = tesseract("chi_sim"))
text2 <- ocr(file, engine = tesseract("chi_sim", datapath = dir))
```

this PR fixes that
